### PR TITLE
removed question mark in full detail level url

### DIFF
--- a/src/communities/__tests__/byIds.test.ts
+++ b/src/communities/__tests__/byIds.test.ts
@@ -28,7 +28,7 @@ describe("the communities resource #details", () => {
 
   it("should call the search endpoint", () => {
     expect(mockFetch.mock.calls[0][0]).toBe(
-      "http://localhost:3000/api/v1/communities/123,234&detail_level=FULL"
+      "http://localhost:3000/api/v1/communities/123,234?detail_level=FULL"
     )
   })
 

--- a/src/communities/__tests__/byIds.test.ts
+++ b/src/communities/__tests__/byIds.test.ts
@@ -28,7 +28,7 @@ describe("the communities resource #details", () => {
 
   it("should call the search endpoint", () => {
     expect(mockFetch.mock.calls[0][0]).toBe(
-      "http://localhost:3000/api/v1/communities/?123,234&detail_level=FULL"
+      "http://localhost:3000/api/v1/communities/123,234&detail_level=FULL"
     )
   })
 

--- a/src/communities/index.ts
+++ b/src/communities/index.ts
@@ -19,7 +19,7 @@ const communities = (
 ): IRestResource<ICommunity | IMHBOListing> => ({
   byIds: (params: number[]) =>
     requestGet<ICommunity, IUnparsedCommunity>(
-      `v1/communities/?${params.toString()}&detail_level=FULL`,
+      `v1/communities/${params.toString()}&detail_level=FULL`,
       creds,
       Ienvironment,
       fetchExecutor

--- a/src/communities/index.ts
+++ b/src/communities/index.ts
@@ -19,7 +19,7 @@ const communities = (
 ): IRestResource<ICommunity | IMHBOListing> => ({
   byIds: (params: number[]) =>
     requestGet<ICommunity, IUnparsedCommunity>(
-      `v1/communities/${params.toString()}&detail_level=FULL`,
+      `v1/communities/${params.toString()}?detail_level=FULL`,
       creds,
       Ienvironment,
       fetchExecutor

--- a/src/homes/__tests__/byIds.test.ts
+++ b/src/homes/__tests__/byIds.test.ts
@@ -28,7 +28,7 @@ describe("the homes resource #details", () => {
 
   it("should call the search endpoint", () => {
     expect(mockFetch.mock.calls[0][0]).toBe(
-      "http://localhost:3000/api/v1/mobile_homes/234,2345&detail_level=FULL"
+      "http://localhost:3000/api/v1/mobile_homes/234,2345?detail_level=FULL"
     )
   })
 

--- a/src/homes/__tests__/byIds.test.ts
+++ b/src/homes/__tests__/byIds.test.ts
@@ -28,7 +28,7 @@ describe("the homes resource #details", () => {
 
   it("should call the search endpoint", () => {
     expect(mockFetch.mock.calls[0][0]).toBe(
-      "http://localhost:3000/api/v1/mobile_homes/?234,2345&detail_level=FULL"
+      "http://localhost:3000/api/v1/mobile_homes/234,2345&detail_level=FULL"
     )
   })
 

--- a/src/homes/index.ts
+++ b/src/homes/index.ts
@@ -19,7 +19,7 @@ const homes = (
 ): IRestResource<IMobileHome | IMHBOListing> => ({
   byIds: (params: number[]) =>
     requestGet<IMobileHome, IUnparsedMobileHome>(
-      `v1/mobile_homes/${params.toString()}&detail_level=FULL`,
+      `v1/mobile_homes/${params.toString()}?detail_level=FULL`,
       creds,
       Ienvironment,
       fetchExecutor

--- a/src/homes/index.ts
+++ b/src/homes/index.ts
@@ -19,7 +19,7 @@ const homes = (
 ): IRestResource<IMobileHome | IMHBOListing> => ({
   byIds: (params: number[]) =>
     requestGet<IMobileHome, IUnparsedMobileHome>(
-      `v1/mobile_homes/?${params.toString()}&detail_level=FULL`,
+      `v1/mobile_homes/${params.toString()}&detail_level=FULL`,
       creds,
       Ienvironment,
       fetchExecutor


### PR DESCRIPTION
#32 
The typo is causing the API response to ignore the ids and return default response with detail level full